### PR TITLE
Calculate line position based on real time.

### DIFF
--- a/app/controllers/timetable.js
+++ b/app/controllers/timetable.js
@@ -1,6 +1,6 @@
 import teacherDialogPartial from 'partials/dialog-teacher.html';
 
-export default function($scope, $http, lessonService, $window, $location, weekService, apiService, dayService, timetableData, ngDialog) {
+export default function($scope, $http, lessonService, $window, $location, $interval, weekService, apiService, dayService, timetableData, ngDialog) {
   // Get the personal schedule from the API
   if (timetableData !== false) {
     // Get the title of the timetable and filter some words out of it
@@ -124,5 +124,5 @@ export default function($scope, $http, lessonService, $window, $location, weekSe
     return dayService.setCalculateLine();
   };
 
-  $window.setInterval($scope.calculateLine, 60000); // Refresh every minute
+  $interval($scope.calculateLine, 60000); // Refresh every minute
 }

--- a/app/services/day.js
+++ b/app/services/day.js
@@ -2,7 +2,13 @@ import moment from 'moment';
 
 export default function(weekService) {
   const data = {};
-  const now = moment();
+  let now;
+
+  function updateTime() {
+    now = moment();
+  }
+
+  updateTime();
 
   // List of the breaks and the duration. The first break is after the second hour and is 20 minutes.
   data.hourBreaks = [0, 0, 15, 0, 0, 0, 0, 0, 0, 0, 0, 15, 0, 30, 0];
@@ -55,6 +61,8 @@ export default function(weekService) {
       }
     },
     setCalculateLine() {
+      updateTime();
+
       if (data.dayEndTime > now && data.dayStartTime < now) {
         const percentageComplete = (now - data.dayStartTime) / (data.dayEndTime - data.dayStartTime) * 100;
         const percentageRounded = (Math.round(percentageComplete * 100) / 100);


### PR DESCRIPTION
Fixes #203 

Voor het berekenen van de positie van de rode tijd balk werd een constante tijd gebruikt. Deze changes zorgen er voor dat de tijd eerst wordt geupdate.