### PR TITLE
Fix  #209: Use isoWeek to get weeknumber in the lesson service

### DIFF
--- a/app/services/lesson.js
+++ b/app/services/lesson.js
@@ -95,7 +95,7 @@ export default function() {
     payload.data.forEach(function(lesson) {
       const start = moment(lesson.start);
       const end = moment(lesson.end);
-      const startWeeknumber = start.format('w'); // Output: weeknumber (without leading zero)
+      const startWeeknumber = start.isoWeek(); // Output: weeknumber (without leading zero)
       const startDaynumber = start.format('d'); // Output: daynumber of week (1 - 5), 1 = Monday
 
       // Convert mask to binary and get the length to minimize needed loops


### PR DESCRIPTION
Had wat tijd om deze issue op te lossen. Het begon na een aantal weken toch wel irritant te worden dat je niet direct de juiste week voor je neus krijgt :p  

